### PR TITLE
chore(docs): rewrite README and stack documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,97 +1,119 @@
 # kafSIEM
 
-kafSIEM is an open-source operations and fusion analysis surface. It turns
-Kafka-observed operational traffic and selected OSINT context into an
-auditable entity graph for analyst workflows.
+Edge-ready operations intelligence with an evidence-linked entity graph.
 
-The product can run standalone for teams that need a local, Docker-first
-analysis stack. It can also complement existing enterprise intelligence
-platforms through typed APIs, pack-defined ontology, provenance-preserving
-records, and exportable graph context.
+kafSIEM watches Kafka agent traffic and OSINT feeds, materializes entities and
+relationships in SQLite, and serves analyst workflows through a web desk and
+typed OpenAPI. Deploy with Docker on a single host. No cluster database
+required.
 
-It now ships with three operating modes:
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache--2.0-blue.svg)](LICENSE)
+[![OpenAPI](https://img.shields.io/badge/API-OpenAPI-green)](api/openapi.yaml)
+[![Docker](https://img.shields.io/badge/deploy-docker--compose-blue)](docker-compose.yml)
 
-- `OSINT`: the existing globe-first external intelligence workflow
-- `Operations`: Kafka-backed flow tracking and internal operational workflows
-- `Fusion`: operations plus selective external OSINT context
-
-This repository has been prepared for public use by removing non-public, internal, and protected source integrations while keeping the operational pipeline structure intact.
+Keywords: entity graph, Kafka SIEM, OSINT dashboard, drone fleet operations,
+SCADA security, edge deployment, ontology packs, provenance, SQLite analyst API.
 
 ## Screenshots
 
 <p align="center">
   <a href="public/images/Scalytics-OSINT-Prediction.png">
-    <img src="public/images/Scalytics-OSINT-Prediction.png" alt="kafSIEM OSINT mode screenshot" width="32%" />
+    <img src="public/images/Scalytics-OSINT-Prediction.png" alt="kafSIEM OSINT globe and alert feed" width="32%" />
   </a>
   <a href="public/images/Scalytics-Ontology-Drones.png">
-    <img src="public/images/Scalytics-Ontology-Drones.png" alt="kafSIEM Operations ontology drones screenshot" width="32%" />
+    <img src="public/images/Scalytics-Ontology-Drones.png" alt="kafSIEM Operations desk with drones ontology graph" width="32%" />
   </a>
   <a href="public/images/Scalytics-Ontology-SCADA.png">
-    <img src="public/images/Scalytics-Ontology-SCADA.png" alt="kafSIEM Operations ontology SCADA screenshot" width="32%" />
+    <img src="public/images/Scalytics-Ontology-SCADA.png" alt="kafSIEM Operations desk with SCADA ontology graph" width="32%" />
   </a>
 </p>
 <p align="center">
   <strong>OSINT</strong> | <strong>Operations / Drones</strong> | <strong>Operations / SCADA</strong>
 </p>
 
-## Open-Source Scope
+## Try in 30 seconds
 
-- Public-ready OSINT pipeline architecture
-- Operations flow tracking over Kafka for KafClaw-style agent traffic
-- Entity, edge, provenance, map, and timeline APIs backed by SQLite
-- Pack-defined ontology for unmanned systems and SCADA / critical infrastructure workflows
-- Docker-first deployment for reproducible installs
-- Web dashboard, Go collector runtime, and standalone analyst API service
-- Configurable ingestion and refresh cadence
-
-## Target Deployments
-
-kafSIEM is designed for two initial operations profiles:
-
-- unmanned systems teams that need readiness, sortie, EW, software, and
-  signoff evidence connected across fleet activity
-- SCADA and critical infrastructure teams that need plant, device, change,
-  alarm, firmware, vulnerability, and session evidence connected across
-  operational telemetry
-
-These profiles are shipped as data packs under `packs/`. The active pack
-contract is documented in [docs/packs/drones.md](https://github.com/scalytics/kafSIEM/blob/main/docs/packs/drones.md)
-and [docs/packs/scada.md](https://github.com/scalytics/kafSIEM/blob/main/docs/packs/scada.md).
-
-## Operating Modes
-
-The runtime mode is driven by environment and mounted policy files.
-
-- `UI_MODE=OSINT` keeps the existing OSINT product behavior.
-- `UI_MODE=AGENTOPS` switches the desktop UI to the Operations desk.
-- `UI_MODE=HYBRID` switches the desktop UI to Fusion mode with selective external-intel context.
-
-Current runtime values remain `OSINT`, `AGENTOPS`, and `HYBRID` for
-compatibility. User-facing product naming is `OSINT`, `Operations`, and
-`Fusion`.
-
-AgentOps is a separate bounded domain in the codebase:
-
-- backend: `internal/agentops/...`
-- frontend: `src/agentops/...`
-
-It is not implemented as a generic plugin tree.
-
-Architecture details live in [docs/architecture.md](https://github.com/scalytics/kafSIEM/blob/main/docs/architecture.md).
-
-## Run With Docker
+No Kafka, API keys, or Docker required.
 
 ```bash
-if command -v docker-compose >/dev/null 2>&1; then
-  docker-compose up --build
-else
-  docker compose up --build
-fi
+git clone https://github.com/scalytics/kafSIEM.git && cd kafSIEM
+npm install
+npm run demo:ontology:drones   # unmanned systems ontology desk
+npm run demo:ontology:scada    # SCADA / OT ontology desk
+npm run demo:fusion            # operations plus OSINT correlation
 ```
 
-The application will be available at `http://localhost:8080`.
+Opens the Operations or Fusion desk with typed mock API data. OSINT mode is
+unchanged.
 
-You can also use the Make targets for local HTTP development:
+## What you get
+
+- **Entity graph** stored in SQLite: platforms, faults, devices, agents, tasks.
+  Graph edges can cite the source Kafka record.
+- **Analyst desk**: flow queue, topology graph, map, replay studio, entity
+  profiles, provenance drawer.
+- **Domain packs**: YAML ontology for drones and SCADA. Detectors, queries,
+  views, map layers, report templates. No pack executable code.
+- **Typed API**: `/api/v1/...` with generated [OpenAPI](api/openapi.yaml).
+  Integrates with existing enterprise platforms.
+- **Edge deployment**: collector writes, API reads, shared volume. Docker
+  Compose or Helm.
+
+## Who it is for
+
+**Unmanned systems teams** tracking readiness, sorties, EW events, software
+lineage, and signoff evidence across a fleet.
+
+**SCADA and critical infrastructure teams** connecting plants, devices, change
+audit, alarms, firmware, vulnerabilities, and engineer sessions.
+
+| Pack | Example questions |
+|------|-------------------|
+| [Drones](docs/packs/drones.md) | What changed since last signoff? Is this fault fleet-wide? Which platforms run software version X? |
+| [SCADA](docs/packs/scada.md) | Which changes lack a work order? Is firmware drifting on safety PLCs? What CVEs affect live devices? |
+
+## How it works
+
+```text
+KafClaw agents
+      |
+      v
+KafScale / Kafka
+      |
+      v
+kafsiem-collector  --->  /data/agentops.db (+ WAL/SHM)
+      |                           |
+      | legacy /api/*             v
+      +---------------->  kafsiem-api  --->  Caddy + web UI
+```
+
+The collector ingests OSINT sources and, when enabled, consumes Kafka traffic.
+It is the sole writer for observed operational state. `kafsiem-api` serves
+read-only analyst resources and enqueues replay requests. See
+[Architecture](docs/architecture.md).
+
+## Operating modes
+
+| Product name | `UI_MODE` | Purpose |
+|--------------|-----------|---------|
+| OSINT | `OSINT` | Globe-first external intelligence and alert feeds |
+| Operations | `AGENTOPS` | Kafka agent flow tracking and ontology desk |
+| Fusion | `HYBRID` | Operations plus heuristic OSINT correlation |
+
+Set mode via `UI_MODE` and mounted policy files. User-facing copy uses OSINT,
+Operations, and Fusion. Runtime env values stay `AGENTOPS` and `HYBRID` for
+compatibility.
+
+## Quick start (Docker)
+
+```bash
+cp .env.example .env
+docker compose up --build
+```
+
+UI: `http://localhost:8080`
+
+Make targets for local HTTP dev:
 
 ```bash
 make dev-start
@@ -100,122 +122,54 @@ make dev-restart
 make dev-logs
 ```
 
-The old JSON-backed AgentOps demo UI has been removed. Operations and Fusion
-development uses the live runtime desk against `kafsiem-api` and the
-collector-written SQLite store. For UI-only demos without Kafka or SQLite,
-the same runtime desk can run against typed mock streams:
-
-```bash
-npm run demo:ontology
-npm run demo:fusion
-```
-
-These open `/?demo=ontology` and `/?demo=fusion`, which keep OSINT untouched
-and feed the Operations/Fusion ontology dashboard through mocked typed API
-resources.
-
-## Remote Install (wget bootstrap)
+## Remote install
 
 ```bash
 wget -qO- https://raw.githubusercontent.com/scalytics/kafSIEM/main/deploy/install.sh | bash
 ```
 
-The installer will:
-- verify Docker + Compose availability
-- clone or update the repo on the host
-- ask for the operating profile (`OSINT`, `Operations`, or `Fusion`)
-- set GHCR runtime images (`ghcr.io/scalytics/kafsiem-web` + `ghcr.io/scalytics/kafsiem-collector`)
-- prompt for install mode (`preserve` or `fresh` volume reset)
-- prompt for the common site setting (`KAFSIEM_SITE_ADDRESS`)
-- when domain mode is enabled, optionally check `ufw`/`firewalld` and validate local 80/443 availability
-- prompt only for the profile-relevant runtime keys
-- optionally run `docker compose pull` and start with `--no-build`
+The installer checks Docker, clones or updates the repo, prompts for profile
+(OSINT, Operations, or Fusion), site address, and profile-specific settings,
+then starts GHCR images.
 
-- The release pipeline builds three images: a web image, a Go collector image, and a Go analyst API image.
-- The scheduled feed refresh workflow runs the Go collector.
-- The web image uses Caddy, with collector output mounted into the web container at runtime and `/api/*` reverse-proxied to the standalone analyst API service.
-- In Docker dev mode, the collector initializes empty JSON outputs on a fresh volume and writes live output on the first successful run.
-
-## Run Locally Without Docker
+## API example
 
 ```bash
-volta install node@25.8.1 npm@11.11.0
-npm install
-npm run fetch:alerts:watch
-npm run dev
+curl -s http://localhost:8080/api/v1/ontology/packs | jq .
+curl -s http://localhost:8080/api/v1/flows | jq .
+curl -s http://localhost:8080/api/v1/entities/platform/auv-7 | jq .
 ```
 
-For resilient 24/7 collection with auto-restart on crashes:
+Full contract: [api/openapi.yaml](api/openapi.yaml). Client notes:
+[docs/api-clients.md](docs/api-clients.md).
 
-```bash
-npm run collector:run
-```
+## Stack context
 
-Tuning examples:
+| Component | Role |
+|-----------|------|
+| **KafScale** | External Kafka transport. kafSIEM consumes from it. |
+| **KafClaw** | External agent plane. Emits group envelopes on Kafka topics. |
+| **kafSIEM** | Observer, graph store, API, UI, packs (this repository). |
 
-```bash
-INTERVAL_MS=120000 MAX_PER_SOURCE=80 npm run collector:run
-INTERVAL_MS=120000 RECENT_WINDOW_PER_SOURCE=20 ALERT_STALE_DAYS=14 npm run collector:run
-```
+kafSIEM complements enterprise intelligence platforms. It exposes typed entity
+and graph APIs, pack-defined ontology, and provenance back to source records.
 
-Minimal required runtime variables are in [.env.example](https://github.com/scalytics/kafSIEM/blob/main/.env.example).
-Advanced tuning variables and defaults are documented in [docs/advanced-config.md](https://github.com/scalytics/kafSIEM/blob/main/docs/advanced-config.md).
+## Documentation
 
-## Installer Profiles
+| Topic | Document |
+|-------|----------|
+| Full doc index | [docs/README.md](docs/README.md) |
+| Architecture | [docs/architecture.md](docs/architecture.md) |
+| Operations / Docker / VM | [docs/operations.md](docs/operations.md) |
+| Operations Kafka config | [docs/agentops-operator-guide.md](docs/agentops-operator-guide.md) |
+| API clients | [docs/api-clients.md](docs/api-clients.md) |
+| Drones pack | [docs/packs/drones.md](docs/packs/drones.md) |
+| SCADA pack | [docs/packs/scada.md](docs/packs/scada.md) |
+| OSINT user guide | [docs/userguide.md](docs/userguide.md) |
+| Advanced env tuning | [docs/advanced-config.md](docs/advanced-config.md) |
+| Minimal env template | [.env.example](.env.example) |
 
-The installer is profile-driven and only asks for the settings that matter for the selected operating mode.
-
-- `OSINT`
-  - prompts for `KAFSIEM_SITE_ADDRESS`
-  - prompts for OSINT credentials and optional LLM toggles
-  - writes `UI_MODE=OSINT` and `PROFILE=osint-default`
-- `Operations`
-  - prompts for `KAFSIEM_SITE_ADDRESS`
-  - prompts for AgentOps Kafka brokers, auth mode, group identifiers, topic mode, replay, and optional reject mirroring
-  - writes `UI_MODE=AGENTOPS` and `PROFILE=agentops-default`
-- `Fusion`
-  - prompts for both the OSINT and AgentOps settings above
-  - writes `UI_MODE=HYBRID` and `PROFILE=hybrid-ops`
-
-Advanced settings such as replay prefixes, policy file paths, Kafka poll limits, and TLS overrides stay in `.env` or mounted config files and are not part of the guided install flow.
-
-AgentOps-specific runtime knobs include:
-
-- `AGENTOPS_ENABLED`
-- `AGENTOPS_BROKERS`
-- `AGENTOPS_GROUP_NAME`
-- `AGENTOPS_GROUP_ID`
-- `AGENTOPS_POLICY_PATH`
-- `AGENTOPS_REPLAY_ENABLED`
-- `AGENTOPS_REJECT_TOPIC`
-- `AGENTOPS_OUTPUT_PATH`
-- `KAFSIEM_PACKS_DIR`
-- `UI_MODE`
-- `PROFILE`
-- `UI_POLICY_PATH`
-
-When AgentOps is enabled, the collector writes `agentops.db` into the runtime data volume and the analyst API serves typed `/api/v1/...` resources from that SQLite store.
-
-Mount contract:
-
-- `/config`: policy and UI steering files
-- `/data`: generated AgentOps SQLite state (`agentops.db` plus WAL/SHM sidecars), alerts JSON, and replay metadata
-- `/packs`: active bundled or mounted pack directories
-
-Content behavior is explicit:
-
-- normal Kafka records are decoded from Kafka values and shown in AgentOps detail views
-- LFS-backed records are shown as pointer metadata only (`s3://bucket/key`)
-- the default product flow does not fetch blob content for LFS-backed records
-- rejected records can be mirrored to `AGENTOPS_REJECT_TOPIC`
-- replay always uses a dedicated consumer group and never mutates the live tracking group
-
-Operator reference and examples live in [docs/agentops-operator-guide.md](https://github.com/scalytics/kafSIEM/blob/main/docs/agentops-operator-guide.md).
-The analyst API contract lives in [api/openapi.yaml](https://github.com/scalytics/kafSIEM/blob/main/api/openapi.yaml);
-client guidance is in [docs/api-clients.md](https://github.com/scalytics/kafSIEM/blob/main/docs/api-clients.md)
-and problem details are registered in [docs/agentops-api-errors.md](https://github.com/scalytics/kafSIEM/blob/main/docs/agentops-api-errors.md).
-
-## Operations
+## Development
 
 ```bash
 make check
@@ -223,17 +177,18 @@ make ci
 make docker-build
 ```
 
-- `make release-patch`, `make release-minor`, and `make release-major` create and push semver tags that trigger the release workflow.
-- `.github/workflows/branch-protection.yml` applies protection to `main` using the `ADMIN_GITHUB_TOKEN` repository secret.
-- Docker validation runs through `buildx`, and release images publish to GHCR on semver tags.
-- Release images are published as `ghcr.io/<owner>/<repo>-web` and `ghcr.io/<owner>/<repo>-collector`.
-- `docker-compose up --build` or `docker compose up --build` runs the Go collector as a background refresh service and serves generated JSON through the Caddy web container.
-- VM/domain deployment instructions live in [docs/operations.md](https://github.com/scalytics/kafSIEM/blob/main/docs/operations.md).
-- Noise gate, search defaults, analyst feedback endpoints, and metrics output are documented in [docs/operations.md](https://github.com/scalytics/kafSIEM/blob/main/docs/operations.md#noise-gate-global-noise--contextual-triage).
+Node `25.8.1` and npm `11.11.0` are pinned in `package.json`, `.nvmrc`, and
+`.node-version`. The Go collector powers scheduled feed refresh, Docker
+runtime, and local collection commands.
 
-## Notes
+OSINT-only local dev without Docker:
 
-- Local toolchain is pinned to Node `25.8.1` and npm `11.11.0` via `package.json`, `.nvmrc`, and `.node-version`.
-- The Go collector is the operational backend for scheduled feed refreshes, Docker runtime, and local commands.
-- This repository intentionally excludes non-public/internal/protected integrations and is maintained as the open-source-ready distribution.
-- The root `LICENSE` applies to repository-local materials and modifications.
+```bash
+npm install
+npm run fetch:alerts:watch
+npm run dev
+```
+
+## License
+
+Apache-2.0. See [LICENSE](LICENSE).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,68 @@
+# kafSIEM Documentation
+
+kafSIEM is an edge-deployable operations intelligence platform. It builds an
+entity graph from Kafka agent traffic and OSINT feeds, stores state in SQLite,
+and serves analyst workflows through a web UI and OpenAPI.
+
+## Start here
+
+| Goal | Document |
+|------|----------|
+| Product overview and quick start | [README](../README.md) |
+| System design and package layout | [architecture.md](architecture.md) |
+| Docker, VM, installer, collector roles | [operations.md](operations.md) |
+| Kafka observer, volumes, backup, replay | [agentops-operator-guide.md](agentops-operator-guide.md) |
+| OpenAPI clients (TypeScript, Go) | [api-clients.md](api-clients.md) |
+| API error types (RFC 9457) | [agentops-api-errors.md](agentops-api-errors.md) |
+
+## Operating modes
+
+| Mode | `UI_MODE` | Summary |
+|------|-----------|---------|
+| OSINT | `OSINT` | External intelligence: alerts, globe, zone briefings |
+| Operations | `AGENTOPS` | Kafka flow tracking, entity graph, ontology desk |
+| Fusion | `HYBRID` | Operations plus OSINT correlation in one UI |
+
+## Domain packs
+
+Packs declare ontology, detectors, queries, views, map layers, and reports as
+YAML. No pack executable code. Restart services to change active packs.
+
+| Pack | Document | Use case |
+|------|----------|----------|
+| Drones | [packs/drones.md](packs/drones.md) | Fleet readiness, sorties, EW, software, signoff |
+| SCADA | [packs/scada.md](packs/scada.md) | Plant, device, change audit, alarms, firmware, CVE |
+
+Pack sources live under [`packs/`](../packs/).
+
+## OSINT
+
+| Topic | Document |
+|-------|----------|
+| Alert categories and UI | [userguide.md](userguide.md) |
+| Source vetting | [source-vetting.md](source-vetting.md) |
+| ACLED integration | [acled.md](acled.md) |
+| Collector migration | [collector-migration.md](collector-migration.md) |
+
+## Configuration
+
+| Topic | Document |
+|-------|----------|
+| Minimal runtime env | [.env.example](../.env.example) |
+| Advanced tuning | [advanced-config.md](advanced-config.md) |
+| v1 to v2 upgrade | [upgrades/v1-to-v2.md](upgrades/v1-to-v2.md) |
+
+## API reference
+
+Generated OpenAPI: [api/openapi.yaml](../api/openapi.yaml)
+
+Key `/api/v1` surfaces:
+
+- `GET /entities/{type}/{id}` plus neighborhood, provenance, geometry, timeline
+- `GET /flows`, `GET /flows/{id}/messages`, tasks, traces
+- `GET /graph/path`, `GET /search`
+- `GET /map/layers`, `GET /map/features`
+- `GET /ontology/types`, `GET /ontology/packs`
+- `GET /replays`, `POST /replays`
+
+Legacy OSINT routes under `/api/*` proxy to the collector where configured.

--- a/docs/acled.md
+++ b/docs/acled.md
@@ -10,7 +10,8 @@ kafSIEM integrates with the [Armed Conflict Location & Event Data](https://acled
 ## Setup
 
 1. Register at **https://acleddata.com/register/**
-2. **Use an institutional email** (`@yourorg.com`) — gmail and other public email addresses only grant "Open myACLED" (web-based data export), which does **not** include API access
+2. **Use an institutional email** (`@yourorg.com`). Public email addresses only
+   grant web export ("Open myACLED"), not API access.
 3. Institutional accounts should have API access by default. If not, contact `access@acleddata.com` to request the API tier
 4. Set credentials in `.env`:
 
@@ -21,7 +22,8 @@ ACLED_PASSWORD=your-password
 
 5. The collector will automatically start pulling ACLED events on the next run.
 
-If credentials are not set, the ACLED source is silently skipped — all other sources continue normally.
+If credentials are not set, the ACLED source is silently skipped. All other
+sources continue normally.
 
 ### Verifying API Access
 
@@ -36,7 +38,7 @@ TOKEN=$(curl -s -X POST "https://acleddata.com/oauth/token" \
   -d "grant_type=password" \
   -d "client_id=acled" | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
 
-# Test the API — should return JSON data, not "Access denied"
+# Test the API. Expect JSON data, not "Access denied".
 curl -s -H "Authorization: Bearer $TOKEN" \
   "https://acleddata.com/api/acled/read?_format=json&limit=2"
 ```
@@ -57,9 +59,9 @@ A new token is obtained at the start of each collection run. No token caching or
 
 ```
 ACLED API (/api/acled/read)
-  → parse.ParseACLED()         — JSON → ACLEDItem (with lat/lng, event type, fatalities)
-  → normalize.ACLEDAlert()     — category/severity mapping, ISO3→ISO2 country, geo override
-  → standard pipeline          — FTS indexing, trend detection, country digest, globe view
+  → parse.ParseACLED()         JSON to ACLEDItem (lat/lng, event type, fatalities)
+  → normalize.ACLEDAlert()     category/severity, ISO3 to ISO2, geo override
+  → standard pipeline          FTS, trends, country digest, globe view
 ```
 
 ## Event Type Mapping

--- a/docs/agentops-operator-guide.md
+++ b/docs/agentops-operator-guide.md
@@ -1,19 +1,17 @@
-# AgentOps Operator Guide
+# Operations Kafka Operator Guide
 
-AgentOps is the internal Kafka-backed observer domain that powers the
-Operations and Fusion surfaces. It tracks KafClaw-style group traffic on
-KafScale, writes durable state to SQLite, and exposes that state through the
-standalone kafSIEM analyst API.
+Kafka observer configuration for kafSIEM Operations and Fusion modes. The
+observer consumes KafClaw group envelopes from KafScale, writes SQLite graph
+state, and exposes data through `kafsiem-api`.
 
-The user-facing modes remain:
+Code and environment variables use the internal name `AgentOps`. User-facing
+product names are Operations and Fusion (`UI_MODE=AGENTOPS` or `HYBRID`).
 
-- `OSINT` for external intelligence workflows
-- `Operations` for internal telemetry, agent traffic, plant, fleet, and system
-  operations
-- `Fusion` for workflows that join operations data with selected OSINT context
-
-Runtime environment values remain `OSINT`, `AGENTOPS`, and `HYBRID` for
-compatibility.
+| Product mode | `UI_MODE` | Kafka |
+|--------------|-----------|-------|
+| OSINT | `OSINT` | Disabled |
+| Operations | `AGENTOPS` | Required |
+| Fusion | `HYBRID` | Required plus OSINT collector |
 
 ## Process Model
 

--- a/docs/api-clients.md
+++ b/docs/api-clients.md
@@ -1,7 +1,10 @@
 # API Clients
 
-The kafSIEM analyst API is served by `cmd/kafsiem-api` and versioned under
-`/api/v1`. The generated OpenAPI contract is [api/openapi.yaml](../api/openapi.yaml).
+kafSIEM analyst API clients for the entity graph, flows, search, maps, and
+ontology endpoints.
+
+Service: `cmd/kafsiem-api`. Base path: `/api/v1`. OpenAPI contract:
+[api/openapi.yaml](../api/openapi.yaml). Error shapes: [agentops-api-errors.md](agentops-api-errors.md).
 
 Regenerate API artifacts after changing the source contract:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,140 +1,172 @@
 # Architecture
 
-kafSIEM is an entity-centric operations and fusion analysis surface. It joins
-Kafka-observed operational traffic with selected OSINT context, writes durable
-evidence to SQLite, and serves analyst workflows through a typed API and web UI.
+kafSIEM is an entity-centric operations and fusion platform. It consumes
+Kafka-observed agent traffic and OSINT feeds, persists evidence in SQLite, and
+exposes analyst workflows through a typed API and React UI.
 
-It is designed to complement existing enterprise intelligence platforms rather
-than replace them. The integration contract is explicit: kafSIEM exposes
-OpenAPI, ontology endpoints, pack-defined types, provenance, map features, and
-graph neighborhoods that other systems can consume.
+Integration contract for external systems: OpenAPI, ontology endpoints,
+pack-defined types, provenance, map features, and graph neighborhoods.
 
-## Product Boundary
+## Product boundary
 
 kafSIEM is the product in this repository.
 
-- KafScale is the external Kafka transport spine. kafSIEM reads from it.
-- KafClaw-style agents are external producers. They emit messages onto
-  KafScale topics.
-- AgentOps is the internal observer domain that tracks that traffic.
-- Packs are constrained domain interfaces, not plugins.
+| External | Role |
+|----------|------|
+| KafScale | Kafka transport spine. kafSIEM reads from it. |
+| KafClaw | Agent and workflow producers. Emit envelopes on group topics. |
+| Enterprise platforms | Optional consumers of kafSIEM graph and ontology APIs |
 
-The v1 product ships two operating packs:
+Internal concepts:
 
-- `drones`: unmanned systems readiness, sortie, EW, software, and signoff
-  workflows
-- `scada`: plant, device, change, alarm, firmware, vulnerability, and session
-  workflows
+- **Operations observer** (`internal/agentops/`): Kafka consumer, replay,
+  policy, SQLite store, KafClaw envelope handling. Code and env still use the
+  `AgentOps` name.
+- **Packs** (`packs/`, `internal/packs/`): Constrained domain interfaces. YAML
+  only. Not a plugin runtime.
 
-## Operating Modes
+Shipped packs:
 
-- `OSINT`: external intelligence and source-driven research
-- `Operations`: internal telemetry, agent traffic, plant, fleet, system
-  operations, and workflow state
-- `Fusion`: joined workflows where OSINT and operations data are used together
+- `drones`: unmanned systems readiness, sortie, EW, software, signoff
+- `scada`: plant, device, change, alarm, firmware, vulnerability, session
 
-Runtime values remain `OSINT`, `AGENTOPS`, and `HYBRID` for compatibility.
-User-facing copy should use `OSINT`, `Operations`, and `Fusion`.
+## Operating modes
 
-## Package Layout
+| Product name | Runtime `UI_MODE` | Data sources |
+|--------------|-------------------|--------------|
+| OSINT | `OSINT` | Curated feeds, browser scrape, optional LLM gates |
+| Operations | `AGENTOPS` | Kafka group traffic, packs, SQLite graph |
+| Fusion | `HYBRID` | Both. UI correlates flows with OSINT alerts heuristically |
 
-- `cmd/kafsiem-collector/`: ingest binary
-- `cmd/kafsiem-api/`: standalone analyst API binary
-- `cmd/pack-docs/`: generated pack reference docs
-- `internal/agentops/`: Kafka observer, replay, policy, SQLite store, and
-  KafClaw envelope handling
-- `internal/graph/`: entity, edge, provenance, geometry, and traversal storage
-- `internal/packs/`: pack loader, validation, and ontology registration
-- `internal/kafsiemapi/`: HTTP API serving typed analyst resources
-- `packs/`: bundled drones and SCADA pack declarations
-- `src/agentops/`: Operations and Fusion UI surfaces
-- `src/agentops/lib/api-client/`: generated TypeScript API client
-- `api/`: generated OpenAPI contract and spec generator
-
-## Runtime Topology
+## Package layout
 
 ```text
-KafClaw-style agents
-        |
-        v
-KafScale / Kafka topics
-        |
-        v
-cmd/kafsiem-collector  --->  /data/agentops.db (+ WAL/SHM)
-        |                              |
-        | legacy /api/*                v
-        +---------------------> cmd/kafsiem-api
-                                      |
-                                      v
-                              Caddy + web UI
+cmd/kafsiem-collector/   ingest binary (OSINT + Kafka observer)
+cmd/kafsiem-api/         analyst API binary (read path)
+cmd/pack-docs/           generated pack reference docs
+internal/agentops/       Kafka observer, store, policy, envelopes
+internal/graph/          entities, edges, provenance, geometry, queries
+internal/packs/          pack loader and validation
+internal/kafsiemapi/     HTTP handlers for /api/v1
+internal/collector/      OSINT fetch, normalize, noise gate, output
+packs/                   bundled drones and SCADA declarations
+src/agentops/            Operations and Fusion UI
+src/osint/               OSINT UI
+api/                     OpenAPI spec generator and generated contract
 ```
 
-The collector is responsible for ingest and writes. The analyst API is
-responsible for reads, typed query surfaces, and legacy route compatibility.
+## Runtime topology
 
-## Storage Contract
+Docker Compose runs four application services plus shared volumes:
 
-AgentOps state is stored in SQLite at `/data/agentops.db` in Docker. WAL mode
-means the sidecar files are part of the live storage contract:
+```text
+browser          headless Chrome bridge for scrape sources
+collector        writer: OSINT JSON + agentops.db
+kafsiem-api      reader: /api/v1 analyst resources
+kafsiem          Caddy SPA, reverse proxy to kafsiem-api
+```
 
-- `/data/agentops.db`
-- `/data/agentops.db-wal`
-- `/data/agentops.db-shm`
+Data path for Operations mode:
 
-The collector is the writer for observed AgentOps runtime state. The analyst
-API serves typed resources from the same SQLite file and can enqueue replay
-requests, but it must not rewrite observed records or mutate the live Kafka
-tracking group. Backups must be SQLite-aware or include the DB and sidecars
-together.
+```text
+KafClaw agents
+      |
+      v
+KafScale / Kafka topics
+      |
+      v
+cmd/kafsiem-collector
+      |  decode envelope or LFS pointer
+      |  update flows, tasks, traces
+      |  append entities and edges
+      v
+/data/agentops.db (+ WAL/SHM)
+      |
+      v
+cmd/kafsiem-api  --->  Caddy + React desk
+```
 
-## API Contract
+The collector owns ingest and writes. The analyst API serves reads, search,
+detector execution, and replay request enqueue. It does not mutate the live
+Kafka consumer group or rewrite observed records.
 
-The analyst API is versioned under `/api/v1`. Important surfaces:
+Legacy OSINT endpoints (`/api/health`, `/api/search`, and similar) reverse
+proxy to the collector internal API on port 3001.
 
-- entity profile, neighborhood, provenance, geometry, and timeline
-- graph path lookup
-- flow list/detail/messages/tasks/traces
-- replay list/create
-- map layers and GeoJSON features
-- active ontology types and packs
-- typed search
+## Graph model
 
-`api/openapi.yaml` is generated from `api/specgen/specgen.go`. The generated
-TypeScript client lives under `src/agentops/lib/api-client/`.
+SQLite tables in `internal/graph/schema/schema.sql`:
 
-## Pack Contract
+| Table | Purpose |
+|-------|---------|
+| `entities` | Typed objects. ID format `type:canonical_id` |
+| `edges` | Relationships with `valid_from`, optional `valid_to`, `evidence_msg` |
+| `provenance` | Ingest and policy decisions per subject |
+| `entity_geometry` | GeoJSON features and bounding boxes |
 
-Packs declare domain behavior as YAML and Markdown templates:
+Core entity types from Kafka ingest: `agent`, `task`, `trace`, `topic`,
+`correlation`. Pack entity types (for example `platform`, `device`, `fault`)
+are declared in pack YAML and populated by domain ingest or test fixtures.
+
+Every accepted Kafka record can produce graph edges that reference
+`messages(record_id)` for audit trail.
+
+## Storage contract
+
+Operations state path: `/data/agentops.db` in Docker.
+
+WAL mode requires all three files in backup and restore:
+
+- `agentops.db`
+- `agentops.db-wal`
+- `agentops.db-shm`
+
+Volume mounts:
+
+| Mount | Contents |
+|-------|----------|
+| `/config` | `agentops_policy.yaml`, UI policy |
+| `/data` | `agentops.db`, OSINT JSON outputs, replay metadata |
+| `/packs` | Active pack directories (read-only) |
+
+## API contract
+
+Versioned under `/api/v1`:
+
+- Entity profile, neighborhood, provenance, geometry, timeline
+- Graph path lookup
+- Flow list, detail, messages, tasks, traces
+- Replay list and create
+- Map layers and GeoJSON features
+- Ontology types and packs
+- Typed search (includes pack detector SQL)
+
+`api/openapi.yaml` is generated from `api/specgen/specgen.go`. TypeScript
+client: `src/agentops/lib/api-client/`.
+
+## Pack contract
 
 ```text
 packs/<name>/
-  pack.yaml
-  detectors/*.yaml
-  maps/layers.yaml
-  queries/*.yaml
-  reports/*.md.tmpl
-  views/*.yaml
+  pack.yaml           entity_types, edge_types
+  detectors/*.yaml    SQL over named views
+  queries/*.yaml      analyst query templates
+  views/*.yaml        entity profile field layout
+  maps/layers.yaml    map overlay config
+  reports/*.md.tmpl   signoff and incident report templates
 ```
 
-Pack validation is startup-time. Operators restart services to change active
-packs. There is no hot reload and no pack-local executable code.
+Validation runs at API and collector startup. No hot reload. No pack-local
+executable code.
 
-Generated pack references:
+Generated references: [packs/drones.md](packs/drones.md),
+[packs/scada.md](packs/scada.md).
 
-- [Drones pack](packs/drones.md)
-- [SCADA pack](packs/scada.md)
+## Search and integration keywords
 
-## Complementary Platform Integration
+Entity graph, Kafka observer, SQLite analyst API, edge SIEM, drone fleet
+ontology, SCADA change audit, OSINT fusion, provenance trail, OpenAPI
+operations intelligence, KafClaw envelope, replay consumer group.
 
-kafSIEM should be described as a complementary operations/fusion layer. Public
-docs should avoid positioning the product as a clone or derivative of another
-vendor product.
-
-The practical integration posture is:
-
-- expose typed entity and graph APIs
-- expose active ontology through `/api/v1/ontology/types` and
-  `/api/v1/ontology/packs`
-- preserve provenance back to source records
-- keep packs inspectable as YAML
-- keep generated OpenAPI stable for external client generation
+Public positioning: complementary operations and fusion layer. Not a vendor
+platform clone. Stable OpenAPI for external client generation.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -5,13 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 
 # Operations
 
-## Runtime Model
+Docker deployment, VM setup, collector roles, OSINT discovery, and noise gate
+configuration for kafSIEM.
 
-The production stack has three containers:
+## Runtime model
 
-- `browser`: always-on headless browser bridge (Chrome DevTools websocket)
-- `collector`: the Go collector running in watch mode and writing refreshed JSON feeds into a shared Docker volume
-- `kafsiem`: the React bundle served by Caddy, reading the shared JSON volume and serving the UI plus feed files
+Docker Compose runs four application services:
+
+| Service | Role |
+|---------|------|
+| `browser` | Headless Chrome bridge (CDP websocket) for scrape sources |
+| `collector` | Go writer: OSINT JSON feeds and `agentops.db` when Operations is enabled |
+| `kafsiem-api` | Go reader: `/api/v1` analyst API from SQLite |
+| `kafsiem` | Caddy serves the React SPA and reverse-proxies `/api/*` to `kafsiem-api` |
+
+Shared volume `feed-data` holds OSINT JSON, `agentops.db`, and WAL sidecars.
+Mount `./packs` read-only for domain ontology.
 
 The collector can also run in parallel worker roles using role filters:
 
@@ -22,7 +31,10 @@ The collector can also run in parallel worker roles using role filters:
 - `api`: API lane only (non-fast + non-browser)
 - `api-ucdp`, `api-acled`, `api-gdelt`: one collector per API family
 
-The web service no longer uses nginx. Caddy serves the SPA, exposes `/alerts.json`, `/alerts-filtered.json`, `/alerts-state.json`, and `/source-health.json`, and can manage TLS automatically when you give it a real domain.
+Caddy serves the SPA, exposes `/alerts.json`, `/alerts-filtered.json`,
+`/alerts-state.json`, and `/source-health.json`, and requests TLS when
+`KAFSIEM_SITE_ADDRESS` is a real hostname. Architecture detail:
+[architecture.md](architecture.md).
 
 ## Local Compose
 
@@ -44,7 +56,7 @@ Default local behavior:
 - HTTP on `http://localhost:8080`
 - HTTPS listener mapped to `https://localhost:8443` but not used unless `KAFSIEM_SITE_ADDRESS` is changed to a hostname that enables TLS
 - The collector initializes empty JSON outputs on a fresh shared feed volume, then replaces them with live collector output on the first successful run
-- Advanced tuning variables are documented in [docs/advanced-config.md](/Users/alo/Development/scalytics/kafSIEM/docs/advanced-config.md).
+- Advanced tuning: [advanced-config.md](advanced-config.md)
 
 ## Guided Installer Profiles
 
@@ -106,7 +118,8 @@ With a real domain in `KAFSIEM_SITE_ADDRESS`, Caddy will request and renew TLS c
 
 ## VM Service With systemd
 
-Use the checked-in unit at [docs/kafsiem.service](/Users/alo/Development/scalytics/kafSIEM/docs/kafsiem.service) so the stack comes back after host reboots:
+Use the checked-in unit at [kafsiem.service](kafsiem.service) so the stack
+comes back after host reboots:
 
 Install it on the VM:
 
@@ -120,7 +133,8 @@ If the VM only has `docker-compose`, adjust the unit commands accordingly.
 
 ## Browser Watchdog
 
-Run [scripts/browser_watchdog.sh](/Users/alo/Development/scalytics/kafSIEM/scripts/browser_watchdog.sh) on the host every minute. It restarts `kafsiem-browser` when either:
+Run [scripts/browser_watchdog.sh](../scripts/browser_watchdog.sh) on the host
+every minute. It restarts `kafsiem-browser` when either:
 
 - browser health is not healthy/running
 - collector logs show repeated remote websocket fallback warnings
@@ -144,10 +158,10 @@ sudo systemctl enable --now kafsiem-browser-watchdog.timer
 
 - The collector writes feed output into the `feed-data` volume shared with the web container.
 - The UI footer freshness line is derived from `source-health.json.generated_at` and shows the age of the current collector snapshot. It is normal below 20 minutes, warning from 20 to 60 minutes, and stale above 60 minutes.
-- Discovery intake lives in [registry/source_candidates.json](/Users/alo/Development/scalytics/kafSIEM/registry/source_candidates.json).
-- Dead sources are written to the terminal DLQ in `source_dead_letter.json` and are not crawled again.
-- LLM-assisted source vetting is documented in [docs/source-vetting.md](/Users/alo/Development/scalytics/kafSIEM/docs/source-vetting.md).
-- ACLED conflict data integration is documented in [docs/acled.md](/Users/alo/Development/scalytics/kafSIEM/docs/acled.md).
+- Discovery intake: [registry/source_candidates.json](../registry/source_candidates.json)
+- Dead sources go to `source_dead_letter.json` and are not crawled again.
+- Source vetting: [source-vetting.md](source-vetting.md)
+- ACLED integration: [acled.md](acled.md)
 - TLS state and certificates persist in the `caddy-data` volume.
 - Caddy runtime state persists in the `caddy-config` volume.
 - Scheduled refreshes, Docker runtime, and local collection commands all run through the Go collector.
@@ -166,10 +180,14 @@ Discovery requires LLM source vetting to promote candidates into the live regist
 
 ### How it works
 
-1. **Seeding** — Curated sovereign official-statement seeds (head of state/government channels), FIRST.org CSIRT teams, Wikidata police/humanitarian/government orgs, and gap analysis (missing country+category combinations) generate candidate URLs.
-2. **Probing** — Each candidate URL is checked for RSS/Atom feeds or stable HTML listing pages.
-3. **Vetting** — If `SOURCE_VETTING_ENABLED=true`, discovered feeds are sampled and sent to the configured LLM for approval. The LLM scores source quality, operational relevance, and assigns mission tags.
-4. **Promotion** — Approved sources are written into `sources.db` and picked up by the collector on its next sweep.
+1. **Seeding**: curated sovereign official-statement seeds, FIRST.org CSIRT teams,
+   Wikidata orgs, and gap analysis generate candidate URLs.
+2. **Probing**: each candidate URL is checked for RSS/Atom feeds or HTML listing
+   pages.
+3. **Vetting**: when `SOURCE_VETTING_ENABLED=true`, sample items go to the LLM
+   for quality and relevance scoring.
+4. **Promotion**: approved sources are written to `sources.db` for the next
+   collector sweep.
 
 For sovereign official-statement seeds, stricter promotion thresholds are applied only when category is `legislative`.
 
@@ -193,7 +211,10 @@ SOURCE_VETTING_MODEL=grok-4-1-fast
 
 ### Token cost
 
-Discovery vetting is lightweight — each candidate gets a single short prompt with up to 6 sample items. A full discovery cycle with 300+ candidates typically costs under 100k tokens. The cycle runs once per collection interval (default 15 minutes) but most candidates are already deduplicated or filtered by deterministic hygiene before the LLM is called.
+Discovery vetting is lightweight: one short prompt per candidate with up to six
+sample items. A full cycle with 300+ candidates typically costs under 100k
+tokens. The cycle runs each collection interval (default 15 minutes). Most
+candidates are deduplicated before the LLM runs.
 
 To save tokens, disable vetting (`SOURCE_VETTING_ENABLED=false`). Discovery will still run and queue candidates, but they won't be promoted until vetting is re-enabled.
 

--- a/docs/userguide.md
+++ b/docs/userguide.md
@@ -1,4 +1,8 @@
-# kafSIEM User Guide
+# kafSIEM OSINT User Guide
+
+OSINT mode (`UI_MODE=OSINT`): alert categories, sources, globe view, search,
+and noise controls. For Operations and Fusion modes see
+[architecture.md](architecture.md) and [agentops-operator-guide.md](agentops-operator-guide.md).
 
 ## Alert Categories
 
@@ -22,7 +26,8 @@ Active missing person cases including children, endangered adults, and unidentif
 **Sources:** Interpol Yellow Notices (newest 160 per run), NCMEC, NamUs, BKA Vermisste, national police missing person feeds.
 
 ### Public Appeal
-Police appeals for information from the public — witness calls, identification requests, crime tip lines, and community safety notices.
+Police appeals for information from the public: witness calls, identification
+requests, crime tip lines, and community safety notices.
 
 **Sources:** Metropolitan Police, Police.uk, Polizei.de state feeds, Gendarmerie, FBI tips, and regional law enforcement across 30+ countries.
 
@@ -52,7 +57,8 @@ Armed conflict tracking, ceasefire violations, military operations, and peace pr
 **Sources:** ACLED (Armed Conflict Location & Event Data), UN Peace & Security, SIPRI conflict data, OSCE monitoring missions, peacekeeping operation feeds.
 
 ### Humanitarian Security
-Security incidents affecting humanitarian operations — aid worker safety, access restrictions, and operational environment assessments in crisis zones.
+Security incidents affecting humanitarian operations: aid worker safety, access
+restrictions, and operational environment assessments in crisis zones.
 
 **Sources:** ICRC field operations, ICRC IHL updates, UN OCHA, UNHCR, and humanitarian coordination feeds.
 
@@ -145,7 +151,9 @@ The default list filters out sports (football, basketball, cricket, FIFA, UEFA, 
 
 ### Customising the list
 
-Edit `registry/stop_words.json` directly — it is a simple JSON file with a `stop_words` array of case-insensitive substring terms. Restart the collector to pick up changes.
+Edit `registry/stop_words.json` directly. It is a JSON file with a `stop_words`
+array of case-insensitive substring terms. Restart the collector to pick up
+changes.
 
 ```json
 {


### PR DESCRIPTION
Restructure the README for faster evaluation: demo-first quick start, operating modes table, stack diagram, API examples, and doc index. Add docs/README.md as the documentation hub. Update architecture, operations, operator guide, and API client docs for the four-service Docker stack (collector, kafsiem-api, kafsiem, browser). Fix broken absolute paths in operations.md. Tighten copy for search keywords and remove em-dashes from touched docs.