### PR TITLE
build: bump collector build image to golang:1.26-alpine

### DIFF
--- a/Dockerfile.collector
+++ b/Dockerfile.collector
@@ -1,7 +1,7 @@
 # Copyright 2024 ff, Scalytics, Inc. - https://www.scalytics.io
 # SPDX-License-Identifier: Apache-2.0
 
-FROM --platform=$BUILDPLATFORM golang:1.25-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS build
 
 WORKDIR /app
 ARG TARGETOS


### PR DESCRIPTION
chromedp 0.15.x raises the `go` directive in `go.mod` to 1.26 (dependabot #45), but `Dockerfile.collector` builds with `golang:1.25-alpine` and `GOTOOLCHAIN=local`, so `go mod download` fails:

```
go: go.mod requires go >= 1.26 (running go 1.25.12; GOTOOLCHAIN=local)
```

This aligns the collector build image with the toolchain requirement. CI and CodeQL already use `go-version-file: go.mod` and follow automatically; the other Dockerfiles don't build Go.

Unblocks #45.