### PR TITLE
Add MoWaS warning alerts

### DIFF
--- a/internal/collector/model/source.go
+++ b/internal/collector/model/source.go
@@ -5,7 +5,8 @@ package model
 
 // Supported source types: rss, x, html-list, kev-json, interpol-red-json,
 // interpol-yellow-json, fbi-wanted-json, travelwarning-json, travelwarning-atom,
-// acled-json, ucdp-json, usgs-geojson, eonet-json, gdelt-json, feodo-json.
+// bbk-mowas-json, acled-json, ucdp-json, usgs-geojson, eonet-json, gdelt-json,
+// feodo-json.
 type RegistrySource struct {
 	Type            string            `json:"type"`
 	FetchMode       string            `json:"fetch_mode,omitempty"` // "stealth" (default) or "browser"

--- a/internal/collector/normalize/mowas.go
+++ b/internal/collector/normalize/mowas.go
@@ -1,0 +1,120 @@
+// Copyright 2024 ff, Scalytics, Inc. - https://www.scalytics.io
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"html"
+	"regexp"
+	"strings"
+
+	"github.com/scalytics/kafSIEM/internal/collector/model"
+	"github.com/scalytics/kafSIEM/internal/collector/parse"
+)
+
+var mowasBreakRE = regexp.MustCompile(`(?i)<br\s*/?>`)
+
+// MOWASAlert preserves the authoritative CAP lifecycle and severity while
+// linking users to the human-facing warnung.bund.de portal.
+func MOWASAlert(ctx Context, meta model.RegistrySource, item parse.MOWASItem) *model.Alert {
+	if strings.TrimSpace(item.Identifier) == "" || strings.TrimSpace(item.Headline) == "" || strings.TrimSpace(item.Link) == "" {
+		return nil
+	}
+	publishedAt := parseDate(item.Published)
+	if publishedAt.IsZero() {
+		publishedAt = ctx.Now
+	}
+
+	summary := cleanMOWASText(strings.Join([]string{item.Description, item.Instruction, item.AreaDesc}, "\n"))
+	alert := baseAlert(ctx, meta, item.Headline, item.Link, item.Headline+"\n"+summary, publishedAt)
+	alert.AlertID = meta.Source.SourceID + ":" + item.Identifier
+	alert.Category = "public_safety"
+	alert.Severity = mowasSeverity(item)
+	alert.Status = mowasStatus(item.MessageType)
+	alert.EventCountry = "Germany"
+	alert.EventCountryCode = "DE"
+	alert.RegionTag = "DE"
+	if strings.TrimSpace(item.Issuer) != "" {
+		alert.Source.AuthorityName = strings.TrimSpace(item.Issuer)
+	}
+	if item.Lat != 0 || item.Lng != 0 {
+		alert.Lat = item.Lat
+		alert.Lng = item.Lng
+		alert.EventGeoSource = "warning-area-centroid"
+		alert.EventGeoConfidence = 0.95
+	}
+	alert.Reporting = model.ReportingMetadata{
+		Label: "View official warning",
+		URL:   item.Link,
+		Notes: "Official warning and current instructions on warnung.bund.de.",
+	}
+
+	tags := append([]string(nil), item.Categories...)
+	tags = append(tags, item.EventCode, item.MessageType, item.Urgency, item.Certainty)
+	relevance := 1.0
+	reasoning := "Official current warning from Germany's modular warning system"
+	if isMOWASInformational(item) {
+		reasoning = "Official cancellation or warning-system test"
+	}
+	alert.Triage = &model.Triage{
+		RelevanceScore:  relevance,
+		Threshold:       ctx.Config.IncidentRelevanceThreshold,
+		Confidence:      "high",
+		Disposition:     "retained",
+		PublicationType: "structured_incident_feed",
+		Reasoning:       reasoning,
+		Metadata: &model.TriageMetadata{
+			Author: strings.TrimSpace(item.Issuer),
+			Tags:   limitStrings(tags, 8),
+		},
+	}
+	assignSubcategory(&alert, summary, strings.Join(tags, " "))
+	return &alert
+}
+
+func mowasStatus(messageType string) string {
+	switch strings.ToLower(strings.TrimSpace(messageType)) {
+	case "update", "cancel":
+		return "updated"
+	default:
+		return "active"
+	}
+}
+
+func mowasSeverity(item parse.MOWASItem) string {
+	if isMOWASInformational(item) {
+		return "info"
+	}
+	switch strings.ToLower(strings.TrimSpace(item.Severity)) {
+	case "extreme":
+		return "critical"
+	case "severe":
+		return "high"
+	case "moderate":
+		return "medium"
+	case "minor":
+		return "low"
+	default:
+		return "medium"
+	}
+}
+
+func isMOWASInformational(item parse.MOWASItem) bool {
+	if strings.EqualFold(strings.TrimSpace(item.MessageType), "cancel") {
+		return true
+	}
+	text := strings.ToLower(item.Headline + " " + item.Description + " " + item.EventCode)
+	return strings.Contains(text, "probealarm") ||
+		strings.Contains(text, "sirenentest") ||
+		strings.Contains(text, "sirenenprobe") ||
+		strings.Contains(text, "funktionsüberprüfung der sirenen") ||
+		strings.Contains(text, "funktionsueberpruefung der sirenen") ||
+		strings.Contains(text, "test warning") ||
+		strings.Contains(text, "bbk-evc-060")
+}
+
+func cleanMOWASText(value string) string {
+	value = mowasBreakRE.ReplaceAllString(value, "\n")
+	value = html.UnescapeString(value)
+	return strings.TrimSpace(value)
+}

--- a/internal/collector/normalize/mowas_test.go
+++ b/internal/collector/normalize/mowas_test.go
@@ -1,0 +1,99 @@
+// Copyright 2024 ff, Scalytics, Inc. - https://www.scalytics.io
+// SPDX-License-Identifier: Apache-2.0
+
+package normalize
+
+import (
+	"testing"
+	"time"
+
+	"github.com/scalytics/kafSIEM/internal/collector/config"
+	"github.com/scalytics/kafSIEM/internal/collector/model"
+	"github.com/scalytics/kafSIEM/internal/collector/parse"
+)
+
+func TestMOWASAlertPreservesIdentitySeverityGeographyAndPortalLink(t *testing.T) {
+	now := time.Date(2026, 8, 1, 8, 0, 0, 0, time.UTC)
+	meta := model.RegistrySource{
+		Type:      "bbk-mowas-json",
+		Category:  "public_safety",
+		RegionTag: "DE",
+		Source: model.SourceMetadata{
+			SourceID:      "bbk-mowas",
+			AuthorityName: "BBK Modular Warning System (MoWaS)",
+			Country:       "Germany",
+			CountryCode:   "DE",
+			Region:        "Europe",
+			AuthorityType: "public_safety_program",
+			BaseURL:       "https://warnung.bund.de",
+		},
+	}
+	item := parse.MOWASItem{
+		Identifier:  "mow.DE-BY-TS-W135-20260801-000",
+		MessageType: "Update",
+		Headline:    "Waldbrand am Hochstaufen",
+		Description: "Gefahr für Leib und Leben.",
+		Instruction: "Meiden Sie das Gebiet.",
+		Issuer:      "Integrierte Leitstelle Traunstein",
+		Published:   "2026-08-01T07:30:00Z",
+		Severity:    "Severe",
+		EventCode:   "BBK-EVC-077",
+		Categories:  []string{"Fire"},
+		Lat:         47.755,
+		Lng:         12.8505,
+		Link:        "https://warnung.bund.de/meldungen/mow_DE-BY-TS-W135-20260801-000/Waldbrand_am_Hochstaufen/",
+	}
+	alert := MOWASAlert(Context{Config: config.Default(), Now: now}, meta, item)
+	if alert == nil {
+		t.Fatal("expected alert")
+	}
+	if alert.AlertID != "bbk-mowas:mow.DE-BY-TS-W135-20260801-000" {
+		t.Fatalf("unexpected stable alert ID %q", alert.AlertID)
+	}
+	if alert.Status != "updated" || alert.Severity != "high" {
+		t.Fatalf("expected updated/high, got %s/%s", alert.Status, alert.Severity)
+	}
+	if alert.Source.AuthorityName != item.Issuer {
+		t.Fatalf("expected issuing authority attribution, got %q", alert.Source.AuthorityName)
+	}
+	if alert.Lat != item.Lat || alert.Lng != item.Lng || alert.EventGeoSource != "warning-area-centroid" {
+		t.Fatalf("unexpected geography: %#v", alert)
+	}
+	if alert.CanonicalURL != item.Link || alert.Reporting.URL != item.Link {
+		t.Fatalf("expected portal URL on alert and reporting metadata: %#v", alert)
+	}
+}
+
+func TestMOWASCancellationAndSirenTestAreInformational(t *testing.T) {
+	cancel := parse.MOWASItem{MessageType: "Cancel", Severity: "Extreme"}
+	if got := mowasSeverity(cancel); got != "info" {
+		t.Fatalf("expected cancellation to be info, got %q", got)
+	}
+	if got := mowasStatus(cancel.MessageType); got != "updated" {
+		t.Fatalf("expected cancellation lifecycle to remain visible as updated, got %q", got)
+	}
+	testAlert := parse.MOWASItem{MessageType: "Alert", Severity: "Severe", EventCode: "BBK-EVC-060"}
+	if got := mowasSeverity(testAlert); got != "info" {
+		t.Fatalf("expected siren test to be info, got %q", got)
+	}
+	liveWording := parse.MOWASItem{MessageType: "Alert", Severity: "Minor", Headline: "Funktionsüberprüfung der Sirenen und Funkmeldeempfänger"}
+	if got := mowasSeverity(liveWording); got != "info" {
+		t.Fatalf("expected live siren-test wording to be info, got %q", got)
+	}
+}
+
+func TestFilterActiveKeepsCurrentMOWASWarningsRegardlessOfStartDate(t *testing.T) {
+	cfg := config.Default()
+	cfg.MaxFreshnessHours = 72
+	alerts := []model.Alert{{
+		AlertID:        "bbk-mowas:long-running",
+		SourceID:       "bbk-mowas",
+		Category:       "public_safety",
+		FreshnessHours: 24 * 200,
+		Triage:         &model.Triage{RelevanceScore: 1},
+	}}
+	active, filtered := FilterActive(cfg, alerts)
+	if len(active) != 1 || len(filtered) != 0 {
+		t.Fatalf("expected provider-current MoWaS warning to bypass generic freshness cap, active=%#v filtered=%#v", active, filtered)
+	}
+}

--- a/internal/collector/normalize/normalize.go
+++ b/internal/collector/normalize/normalize.go
@@ -2072,7 +2072,9 @@ func FilterActive(cfg config.Config, alerts []model.Alert) (active []model.Alert
 		// advisories stay relevant longer.
 		// Certain categories are exempt — wanted/missing persons stay
 		// relevant indefinitely regardless of publish age.
-		freshnessExempt := false
+		// MoWaS publishes a current-state feed: an old start date can still
+		// represent a valid warning that has not expired or been cancelled.
+		freshnessExempt := strings.EqualFold(alert.SourceID, "bbk-mowas")
 		switch strings.ToLower(alert.Category) {
 		case "wanted_suspect", "missing_person", "public_appeal":
 			freshnessExempt = true

--- a/internal/collector/parse/mowas.go
+++ b/internal/collector/parse/mowas.go
@@ -1,0 +1,337 @@
+// Copyright 2024 ff, Scalytics, Inc. - https://www.scalytics.io
+// SPDX-License-Identifier: Apache-2.0
+
+package parse
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"net/url"
+	"sort"
+	"strings"
+)
+
+// MOWASMapItem is the compact nationwide warning record published by
+// warnung.bund.de. The version changes when an existing warning is updated.
+type MOWASMapItem struct {
+	ID          string            `json:"id"`
+	Version     int               `json:"version"`
+	StartDate   string            `json:"startDate"`
+	ExpiresDate string            `json:"expiresDate"`
+	Severity    string            `json:"severity"`
+	Urgency     string            `json:"urgency"`
+	Type        string            `json:"type"`
+	I18NTitle   map[string]string `json:"i18nTitle"`
+}
+
+type mowasDetail struct {
+	Identifier string      `json:"identifier"`
+	Sender     string      `json:"sender"`
+	Sent       string      `json:"sent"`
+	Status     string      `json:"status"`
+	MsgType    string      `json:"msgType"`
+	Scope      string      `json:"scope"`
+	Info       []mowasInfo `json:"info"`
+}
+
+type mowasInfo struct {
+	Language    string       `json:"language"`
+	Category    []string     `json:"category"`
+	Event       string       `json:"event"`
+	Urgency     string       `json:"urgency"`
+	Severity    string       `json:"severity"`
+	Certainty   string       `json:"certainty"`
+	EventCode   []mowasValue `json:"eventCode"`
+	Headline    string       `json:"headline"`
+	Description string       `json:"description"`
+	Instruction string       `json:"instruction"`
+	Contact     string       `json:"contact"`
+	Parameter   []mowasValue `json:"parameter"`
+	Area        []mowasArea  `json:"area"`
+}
+
+type mowasValue struct {
+	ValueName string `json:"valueName"`
+	Value     string `json:"value"`
+}
+
+type mowasArea struct {
+	AreaDesc string `json:"areaDesc"`
+}
+
+type mowasFeatureCollection struct {
+	Features []mowasFeature `json:"features"`
+}
+
+type mowasFeature struct {
+	Geometry mowasGeometry `json:"geometry"`
+}
+
+type mowasGeometry struct {
+	Type        string          `json:"type"`
+	Coordinates json.RawMessage `json:"coordinates"`
+}
+
+// MOWASItem is the normalized CAP-style warning consumed by the collector.
+type MOWASItem struct {
+	Identifier  string
+	Version     int
+	MessageType string
+	Status      string
+	Headline    string
+	Description string
+	Instruction string
+	Contact     string
+	Issuer      string
+	AreaDesc    string
+	Published   string
+	Expires     string
+	Severity    string
+	Urgency     string
+	Certainty   string
+	EventCode   string
+	Categories  []string
+	Lat         float64
+	Lng         float64
+	Link        string
+}
+
+func ParseMOWASMap(body []byte) ([]MOWASMapItem, error) {
+	var items []MOWASMapItem
+	if err := json.Unmarshal(body, &items); err != nil {
+		return nil, err
+	}
+	filtered := items[:0]
+	for _, item := range items {
+		if strings.TrimSpace(item.ID) == "" {
+			continue
+		}
+		filtered = append(filtered, item)
+	}
+	sort.SliceStable(filtered, func(i, j int) bool {
+		return filtered[i].StartDate > filtered[j].StartDate
+	})
+	return filtered, nil
+}
+
+func ParseMOWASDetail(body []byte, summary MOWASMapItem, portalBase string) (MOWASItem, error) {
+	var detail mowasDetail
+	if err := json.Unmarshal(body, &detail); err != nil {
+		return MOWASItem{}, err
+	}
+	identifier := firstNonEmpty(detail.Identifier, summary.ID)
+	if identifier == "" {
+		return MOWASItem{}, fmt.Errorf("MoWaS warning has no identifier")
+	}
+	info, ok := preferredMOWASInfo(detail.Info)
+	if !ok {
+		return MOWASItem{}, fmt.Errorf("MoWaS warning %s has no info block", identifier)
+	}
+	headline := firstNonEmpty(info.Headline, summary.I18NTitle["de"], summary.I18NTitle["en"])
+	if headline == "" {
+		return MOWASItem{}, fmt.Errorf("MoWaS warning %s has no headline", identifier)
+	}
+
+	return MOWASItem{
+		Identifier:  identifier,
+		Version:     summary.Version,
+		MessageType: firstNonEmpty(detail.MsgType, summary.Type),
+		Status:      detail.Status,
+		Headline:    headline,
+		Description: info.Description,
+		Instruction: info.Instruction,
+		Contact:     info.Contact,
+		Issuer:      mowasParameter(info.Parameter, "sender_langname"),
+		AreaDesc:    joinMOWASAreas(info.Area),
+		Published:   firstNonEmpty(detail.Sent, summary.StartDate),
+		Expires:     summary.ExpiresDate,
+		Severity:    firstNonEmpty(info.Severity, summary.Severity),
+		Urgency:     firstNonEmpty(info.Urgency, summary.Urgency),
+		Certainty:   info.Certainty,
+		EventCode:   firstMOWASEventCode(info.EventCode),
+		Categories:  append([]string(nil), info.Category...),
+		Link:        MOWASPortalURL(portalBase, identifier, headline),
+	}, nil
+}
+
+func preferredMOWASInfo(infos []mowasInfo) (mowasInfo, bool) {
+	if len(infos) == 0 {
+		return mowasInfo{}, false
+	}
+	for _, language := range []string{"de", "en"} {
+		for _, info := range infos {
+			if strings.EqualFold(strings.TrimSpace(info.Language), language) {
+				return info, true
+			}
+		}
+	}
+	return infos[0], true
+}
+
+func firstMOWASEventCode(values []mowasValue) string {
+	for _, value := range values {
+		if strings.TrimSpace(value.Value) != "" {
+			return strings.TrimSpace(value.Value)
+		}
+	}
+	return ""
+}
+
+func mowasParameter(values []mowasValue, name string) string {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value.ValueName), name) {
+			return strings.TrimSpace(value.Value)
+		}
+	}
+	return ""
+}
+
+func joinMOWASAreas(areas []mowasArea) string {
+	values := make([]string, 0, len(areas))
+	for _, area := range areas {
+		if value := strings.TrimSpace(area.AreaDesc); value != "" {
+			values = append(values, value)
+		}
+	}
+	return strings.Join(values, "; ")
+}
+
+// MOWASPortalURL builds the human-facing official warning URL. Raw API URLs
+// are deliberately never exposed as alert links.
+func MOWASPortalURL(portalBase, identifier, headline string) string {
+	base := strings.TrimRight(strings.TrimSpace(portalBase), "/")
+	if base == "" {
+		base = "https://warnung.bund.de"
+	}
+	id := strings.ReplaceAll(strings.TrimSpace(identifier), ".", "_")
+	slug := strings.ReplaceAll(strings.TrimSpace(headline), "\"", "'")
+	slug = strings.ReplaceAll(slug, " ", "_")
+	if slug == "" {
+		return base + "/meldungen/" + url.PathEscape(id) + "/"
+	}
+	return base + "/meldungen/" + url.PathEscape(id) + "/" + url.PathEscape(slug) + "/"
+}
+
+// ParseMOWASGeoJSON returns a representative point for the official warning
+// area. Polygon centroids are area-weighted; points and multipoints are also
+// accepted for forward compatibility.
+func ParseMOWASGeoJSON(body []byte) (lat, lng float64, ok bool, err error) {
+	var doc mowasFeatureCollection
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return 0, 0, false, err
+	}
+	totalWeight := 0.0
+	for _, feature := range doc.Features {
+		featureLat, featureLng, weight, found, featureErr := geometryCentroid(feature.Geometry)
+		if featureErr != nil {
+			return 0, 0, false, featureErr
+		}
+		if !found {
+			continue
+		}
+		if weight <= 0 {
+			weight = 1
+		}
+		lat += featureLat * weight
+		lng += featureLng * weight
+		totalWeight += weight
+	}
+	if totalWeight == 0 {
+		return 0, 0, false, nil
+	}
+	return lat / totalWeight, lng / totalWeight, true, nil
+}
+
+func geometryCentroid(geometry mowasGeometry) (lat, lng, weight float64, ok bool, err error) {
+	switch strings.ToLower(strings.TrimSpace(geometry.Type)) {
+	case "point":
+		var point []float64
+		if err := json.Unmarshal(geometry.Coordinates, &point); err != nil {
+			return 0, 0, 0, false, err
+		}
+		if len(point) < 2 {
+			return 0, 0, 0, false, nil
+		}
+		return point[1], point[0], 1, true, nil
+	case "multipoint":
+		var points [][]float64
+		if err := json.Unmarshal(geometry.Coordinates, &points); err != nil {
+			return 0, 0, 0, false, err
+		}
+		return averagePoints(points)
+	case "polygon":
+		var polygon [][][]float64
+		if err := json.Unmarshal(geometry.Coordinates, &polygon); err != nil {
+			return 0, 0, 0, false, err
+		}
+		return polygonCentroid(polygon)
+	case "multipolygon":
+		var polygons [][][][]float64
+		if err := json.Unmarshal(geometry.Coordinates, &polygons); err != nil {
+			return 0, 0, 0, false, err
+		}
+		for _, polygon := range polygons {
+			polygonLat, polygonLng, polygonWeight, found, polygonErr := polygonCentroid(polygon)
+			if polygonErr != nil {
+				return 0, 0, 0, false, polygonErr
+			}
+			if !found {
+				continue
+			}
+			lat += polygonLat * polygonWeight
+			lng += polygonLng * polygonWeight
+			weight += polygonWeight
+		}
+		if weight == 0 {
+			return 0, 0, 0, false, nil
+		}
+		return lat / weight, lng / weight, weight, true, nil
+	default:
+		return 0, 0, 0, false, nil
+	}
+}
+
+func polygonCentroid(polygon [][][]float64) (lat, lng, weight float64, ok bool, err error) {
+	if len(polygon) == 0 {
+		return 0, 0, 0, false, nil
+	}
+	ring := polygon[0]
+	if len(ring) < 3 {
+		return averagePoints(ring)
+	}
+	area2 := 0.0
+	cx := 0.0
+	cy := 0.0
+	for i := 0; i < len(ring)-1; i++ {
+		if len(ring[i]) < 2 || len(ring[i+1]) < 2 {
+			continue
+		}
+		x1, y1 := ring[i][0], ring[i][1]
+		x2, y2 := ring[i+1][0], ring[i+1][1]
+		cross := x1*y2 - x2*y1
+		area2 += cross
+		cx += (x1 + x2) * cross
+		cy += (y1 + y2) * cross
+	}
+	if math.Abs(area2) < 1e-12 {
+		return averagePoints(ring)
+	}
+	return cy / (3 * area2), cx / (3 * area2), math.Abs(area2) / 2, true, nil
+}
+
+func averagePoints(points [][]float64) (lat, lng, weight float64, ok bool, err error) {
+	count := 0.0
+	for _, point := range points {
+		if len(point) < 2 {
+			continue
+		}
+		lng += point[0]
+		lat += point[1]
+		count++
+	}
+	if count == 0 {
+		return 0, 0, 0, false, nil
+	}
+	return lat / count, lng / count, count, true, nil
+}

--- a/internal/collector/parse/mowas_test.go
+++ b/internal/collector/parse/mowas_test.go
@@ -1,0 +1,76 @@
+// Copyright 2024 ff, Scalytics, Inc. - https://www.scalytics.io
+// SPDX-License-Identifier: Apache-2.0
+
+package parse
+
+import (
+	"math"
+	"strings"
+	"testing"
+)
+
+func TestParseMOWASDetailPrefersGermanAndBuildsPortalLink(t *testing.T) {
+	summary := MOWASMapItem{
+		ID:        "mow.DE-BY-TS-W135-20260801-000",
+		Version:   19,
+		StartDate: "2026-08-01T03:00:03+02:00",
+		Severity:  "Minor",
+		Type:      "Update",
+	}
+	body := []byte(`{
+      "identifier":"mow.DE-BY-TS-W135-20260801-000",
+      "sent":"2026-08-01T03:30:03+02:00",
+      "status":"Actual",
+      "msgType":"Update",
+      "info":[
+        {"language":"en","headline":"Forest fire"},
+        {"language":"de","category":["Fire"],"headline":"Waldbrand am Hochstaufen","description":"Gefahr für Leib und Leben.","instruction":"Meiden Sie das Gebiet.","severity":"Severe","urgency":"Immediate","certainty":"Observed","eventCode":[{"valueName":"profile:DE-BBK-EVENTCODE","value":"BBK-EVC-077"}],"parameter":[{"valueName":"sender_langname","value":"Integrierte Leitstelle Traunstein"}],"area":[{"areaDesc":"Bad Reichenhall"}]}
+      ]
+    }`)
+
+	item, err := ParseMOWASDetail(body, summary, "https://warnung.bund.de")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if item.Headline != "Waldbrand am Hochstaufen" {
+		t.Fatalf("expected German headline, got %q", item.Headline)
+	}
+	if item.Issuer != "Integrierte Leitstelle Traunstein" || item.AreaDesc != "Bad Reichenhall" {
+		t.Fatalf("missing issuer or area: %#v", item)
+	}
+	if item.Severity != "Severe" || item.EventCode != "BBK-EVC-077" {
+		t.Fatalf("missing CAP severity or event code: %#v", item)
+	}
+	if !strings.HasPrefix(item.Link, "https://warnung.bund.de/meldungen/mow_DE-BY-TS-W135-20260801-000/") {
+		t.Fatalf("expected human-facing portal URL, got %q", item.Link)
+	}
+	if strings.Contains(item.Link, "/api31/") || strings.HasSuffix(item.Link, ".json") {
+		t.Fatalf("must not expose a raw API URL: %q", item.Link)
+	}
+}
+
+func TestParseMOWASGeoJSONPolygonCentroid(t *testing.T) {
+	body := []byte(`{"type":"FeatureCollection","features":[{"type":"Feature","geometry":{"type":"Polygon","coordinates":[[[10,50],[12,50],[12,52],[10,52],[10,50]]]},"properties":{}}]}`)
+	lat, lng, ok, err := ParseMOWASGeoJSON(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || math.Abs(lat-51) > 1e-9 || math.Abs(lng-11) > 1e-9 {
+		t.Fatalf("expected centroid 51,11, got %f,%f ok=%v", lat, lng, ok)
+	}
+}
+
+func TestParseMOWASMapDropsMissingIDsAndSortsNewestFirst(t *testing.T) {
+	body := []byte(`[
+      {"id":"old","startDate":"2026-08-01T01:00:00+02:00"},
+      {"startDate":"2026-08-01T03:00:00+02:00"},
+      {"id":"new","startDate":"2026-08-01T02:00:00+02:00"}
+    ]`)
+	items, err := ParseMOWASMap(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(items) != 2 || items[0].ID != "new" || items[1].ID != "old" {
+		t.Fatalf("unexpected map ordering: %#v", items)
+	}
+}

--- a/internal/collector/run/run.go
+++ b/internal/collector/run/run.go
@@ -1085,7 +1085,7 @@ func acceptForType(sourceType string) string {
 		return "application/rss+xml, application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8"
 	case "x":
 		return "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
-	case "kev-json", "fbi-wanted-json", "travelwarning-json", "acled-json",
+	case "kev-json", "fbi-wanted-json", "travelwarning-json", "bbk-mowas-json", "acled-json",
 		"usgs-geojson", "eonet-json", "gdelt-json", "feodo-json", "ucdp-json", "nvd-json":
 		return "application/json"
 	case "epss-csv", "urlhaus-csv":
@@ -1160,7 +1160,7 @@ func typePriority(kind string) int {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case "kev-json", "nvd-json", "epss-csv":
 		return 5
-	case "interpol-red-json", "interpol-yellow-json", "fbi-wanted-json", "travelwarning-json", "travelwarning-atom":
+	case "interpol-red-json", "interpol-yellow-json", "fbi-wanted-json", "travelwarning-json", "travelwarning-atom", "bbk-mowas-json":
 		return 4
 	case "usgs-geojson", "eonet-json", "feodo-json", "gdelt-json", "ucdp-json", "urlhaus-csv", "un-sanctions-xml", "ofac-sdn-xml", "opensanctions-json":
 		return 4
@@ -1208,6 +1208,8 @@ func (r Runner) fetchSource(ctx context.Context, fetcher fetch.Fetcher, browser 
 		return r.fetchTravelWarningJSON(ctx, fetcher, nctx, source)
 	case "travelwarning-atom":
 		return r.fetchTravelWarningAtom(ctx, fetcher, nctx, source)
+	case "bbk-mowas-json":
+		return r.fetchMOWAS(ctx, fetcher, nctx, source)
 	case "telegram":
 		return r.fetchTelegram(ctx, fetcher, nctx, source, categoryDictionary)
 	case "usgs-geojson":
@@ -2080,6 +2082,82 @@ func (r Runner) fetchTravelWarningAtom(ctx context.Context, fetcher fetch.Fetche
 		}
 	}
 	return out, nil
+}
+
+func (r Runner) fetchMOWAS(ctx context.Context, fetcher fetch.Fetcher, nctx normalize.Context, source model.RegistrySource) ([]model.Alert, error) {
+	body, err := fetcher.Text(ctx, source.FeedURL, source.FollowRedirects, "application/json")
+	if err != nil {
+		return nil, err
+	}
+	summaries, err := parse.ParseMOWASMap(body)
+	if err != nil {
+		return nil, err
+	}
+	apiBase, portalBase, err := mowasBases(source.FeedURL)
+	if err != nil {
+		return nil, err
+	}
+	limit := perSourceLimit(nctx.Config, source)
+	if len(summaries) > limit {
+		summaries = summaries[:limit]
+	}
+	out := make([]model.Alert, 0, len(summaries))
+	failedDetails := 0
+	for _, summary := range summaries {
+		detailURL := apiBase + "/warnings/" + url.PathEscape(summary.ID) + ".json"
+		detailBody, detailErr := fetcher.Text(ctx, detailURL, source.FollowRedirects, "application/json")
+		if detailErr != nil {
+			failedDetails++
+			fmt.Fprintf(r.stderr, "WARN %s: detail %s: %v\n", source.Source.AuthorityName, summary.ID, detailErr)
+			continue
+		}
+		item, detailErr := parse.ParseMOWASDetail(detailBody, summary, portalBase)
+		if detailErr != nil {
+			failedDetails++
+			fmt.Fprintf(r.stderr, "WARN %s: parse detail %s: %v\n", source.Source.AuthorityName, summary.ID, detailErr)
+			continue
+		}
+
+		geoURL := apiBase + "/warnings/" + url.PathEscape(summary.ID) + ".geojson"
+		if geoBody, geoErr := fetcher.Text(ctx, geoURL, source.FollowRedirects, "application/geo+json, application/json"); geoErr == nil {
+			if lat, lng, ok, parseErr := parse.ParseMOWASGeoJSON(geoBody); parseErr == nil && ok {
+				item.Lat = lat
+				item.Lng = lng
+			} else if parseErr != nil {
+				fmt.Fprintf(r.stderr, "WARN %s: parse geography %s: %v\n", source.Source.AuthorityName, summary.ID, parseErr)
+			}
+		} else {
+			// Geography improves placement but is not required to preserve a
+			// time-critical official warning.
+			fmt.Fprintf(r.stderr, "WARN %s: geography %s: %v\n", source.Source.AuthorityName, summary.ID, geoErr)
+		}
+
+		alert := normalize.MOWASAlert(nctx, source, item)
+		if alert != nil {
+			out = append(out, *alert)
+		}
+	}
+	if len(summaries) > 0 && len(out) == 0 && failedDetails > 0 {
+		return nil, fmt.Errorf("all %d MoWaS warning details failed", failedDetails)
+	}
+	return out, nil
+}
+
+func mowasBases(feedURL string) (apiBase string, portalBase string, err error) {
+	parsed, err := url.Parse(strings.TrimSpace(feedURL))
+	if err != nil {
+		return "", "", fmt.Errorf("parse MoWaS feed URL: %w", err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return "", "", fmt.Errorf("invalid MoWaS feed URL %q", feedURL)
+	}
+	const suffix = "/mowas/mapData.json"
+	if !strings.HasSuffix(parsed.Path, suffix) {
+		return "", "", fmt.Errorf("MoWaS feed URL must end in %s", suffix)
+	}
+	portalBase = parsed.Scheme + "://" + parsed.Host
+	apiBase = portalBase + strings.TrimSuffix(parsed.Path, suffix)
+	return apiBase, portalBase, nil
 }
 
 func (r Runner) fetchUSGSGeoJSON(ctx context.Context, fetcher fetch.Fetcher, nctx normalize.Context, source model.RegistrySource) ([]model.Alert, error) {

--- a/internal/collector/run/run_test.go
+++ b/internal/collector/run/run_test.go
@@ -29,6 +29,16 @@ import (
 	"github.com/scalytics/kafSIEM/internal/sourcedb"
 )
 
+type mapFetcher map[string][]byte
+
+func (f mapFetcher) Text(_ context.Context, rawURL string, _ bool, _ string) ([]byte, error) {
+	body, ok := f[rawURL]
+	if !ok {
+		return nil, fmt.Errorf("unexpected URL %s", rawURL)
+	}
+	return body, nil
+}
+
 func TestRunnerRunOnceWritesOutputs(t *testing.T) {
 	dir := t.TempDir()
 	registryPath := filepath.Join(dir, "registry.json")
@@ -492,6 +502,54 @@ func TestExtractInterpolNoticeID(t *testing.T) {
 	}
 	if got := extractInterpolNoticeID("", "https://ws-public.interpol.int/notices/v1/red/123"); got != "123" {
 		t.Fatalf("expected path id, got %q", got)
+	}
+}
+
+func TestFetchMOWASUsesDetailGeoJSONAndOfficialPortalLink(t *testing.T) {
+	feedURL := "https://warnung.bund.de/api31/mowas/mapData.json"
+	id := "mow.DE-BY-TS-W135-20260801-000"
+	fetcher := mapFetcher{
+		feedURL: []byte(`[{"id":"mow.DE-BY-TS-W135-20260801-000","version":19,"startDate":"2026-08-01T07:30:00Z","severity":"Severe","urgency":"Immediate","type":"Alert","i18nTitle":{"de":"Waldbrand"}}]`),
+		"https://warnung.bund.de/api31/warnings/" + id + ".json":    []byte(`{"identifier":"mow.DE-BY-TS-W135-20260801-000","sent":"2026-08-01T07:30:00Z","status":"Actual","msgType":"Alert","info":[{"language":"de","category":["Fire"],"headline":"Waldbrand am Hochstaufen","description":"Gefahr für Leib und Leben.","instruction":"Meiden Sie das Gebiet.","severity":"Severe","urgency":"Immediate","certainty":"Observed","eventCode":[{"value":"BBK-EVC-077"}],"parameter":[{"valueName":"sender_langname","value":"Integrierte Leitstelle Traunstein"}],"area":[{"areaDesc":"Bad Reichenhall"}]}]}`),
+		"https://warnung.bund.de/api31/warnings/" + id + ".geojson": []byte(`{"type":"FeatureCollection","features":[{"geometry":{"type":"Polygon","coordinates":[[[12,47],[13,47],[13,48],[12,48],[12,47]]]}}]}`),
+	}
+	cfg := config.Default()
+	cfg.MaxAgeDays = 365
+	now := time.Date(2026, 8, 1, 8, 0, 0, 0, time.UTC)
+	source := model.RegistrySource{
+		Type:            "bbk-mowas-json",
+		FollowRedirects: true,
+		FeedURL:         feedURL,
+		Category:        "public_safety",
+		RegionTag:       "DE",
+		MaxItems:        60,
+		Source: model.SourceMetadata{
+			SourceID:      "bbk-mowas",
+			AuthorityName: "BBK Modular Warning System (MoWaS)",
+			Country:       "Germany",
+			CountryCode:   "DE",
+			Region:        "Europe",
+			AuthorityType: "public_safety_program",
+			BaseURL:       "https://warnung.bund.de",
+		},
+	}
+	runner := New(io.Discard, io.Discard)
+	alerts, err := runner.fetchMOWAS(t.Context(), fetcher, normalize.Context{Config: cfg, Now: now}, source)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(alerts) != 1 {
+		t.Fatalf("expected one warning, got %#v", alerts)
+	}
+	alert := alerts[0]
+	if !strings.HasPrefix(alert.CanonicalURL, "https://warnung.bund.de/meldungen/") || strings.Contains(alert.CanonicalURL, "/api31/") {
+		t.Fatalf("expected official human-facing portal link, got %q", alert.CanonicalURL)
+	}
+	if alert.Source.AuthorityName != "Integrierte Leitstelle Traunstein" {
+		t.Fatalf("expected issuing authority, got %q", alert.Source.AuthorityName)
+	}
+	if alert.Lat != 47.5 || alert.Lng != 12.5 {
+		t.Fatalf("expected GeoJSON centroid, got %f,%f", alert.Lat, alert.Lng)
 	}
 }
 

--- a/internal/collector/state/state.go
+++ b/internal/collector/state/state.go
@@ -212,7 +212,12 @@ func Reconcile(cfg config.Config, active []model.Alert, filtered []model.Alert, 
 		if prev, ok := previousByID[alert.AlertID]; ok && prev.FirstSeen != "" {
 			alert.FirstSeen = prev.FirstSeen
 		}
-		alert.Status = "active"
+		// Structured alert systems can explicitly identify updates and
+		// cancellations. Keep that lifecycle visible while the record remains
+		// in the provider's current-alert feed.
+		if alert.Status != "updated" {
+			alert.Status = "active"
+		}
 		alert.LastSeen = nowISO
 		currentActive = append(currentActive, alert)
 	}

--- a/internal/collector/state/state_test.go
+++ b/internal/collector/state/state_test.go
@@ -55,6 +55,21 @@ func TestReconcileCarriesForwardAndRemoves(t *testing.T) {
 	}
 }
 
+func TestReconcilePreservesExplicitUpdatedLifecycle(t *testing.T) {
+	cfg := config.Default()
+	now := time.Date(2026, 8, 1, 8, 0, 0, 0, time.UTC)
+	active := []model.Alert{{
+		AlertID:   "bbk-mowas:warning-1",
+		SourceID:  "bbk-mowas",
+		Status:    "updated",
+		FirstSeen: now.Add(-time.Hour).Format(time.RFC3339),
+	}}
+	currentActive, _, _ := Reconcile(cfg, active, nil, nil, now, nil)
+	if len(currentActive) != 1 || currentActive[0].Status != "updated" {
+		t.Fatalf("expected explicit updated lifecycle, got %#v", currentActive)
+	}
+}
+
 func TestReconcileAccumulateCarriesForward(t *testing.T) {
 	cfg := config.Default()
 	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)

--- a/registry/source_registry.json
+++ b/registry/source_registry.json
@@ -1,5 +1,43 @@
 [
   {
+    "type": "bbk-mowas-json",
+    "followRedirects": true,
+    "source": {
+      "source_id": "bbk-mowas",
+      "authority_name": "BBK Modular Warning System (MoWaS)",
+      "country": "Germany",
+      "country_code": "DE",
+      "region": "Europe",
+      "authority_type": "public_safety_program",
+      "base_url": "https://warnung.bund.de",
+      "scope": "national",
+      "level": "federal",
+      "mission_tags": [
+        "civil-protection",
+        "emergency-warning",
+        "public-safety"
+      ],
+      "operational_relevance": 1,
+      "is_curated": true,
+      "is_high_value": true,
+      "language_code": "de"
+    },
+    "feed_url": "https://warnung.bund.de/api31/mowas/mapData.json",
+    "category": "public_safety",
+    "region_tag": "DE",
+    "lat": 52.52,
+    "lng": 13.405,
+    "source_quality": 1,
+    "promotion_status": "active",
+    "preferred_source_rank": 1,
+    "reporting": {
+      "label": "View official warnings",
+      "url": "https://warnung.bund.de/meldungen",
+      "notes": "Follow the issuing authority's current instructions. Local emergency services take precedence."
+    },
+    "max_items": 60
+  },
+  {
     "type": "kev-json",
     "source": {
       "source_id": "cisa-kev",


### PR DESCRIPTION
## Add MoWaS warning alerts

- ingest official German MoWaS alerts with lifecycle and severity
- use GeoJSON warning-area centroids
- link every alert to its public warnung.bund.de portal page
- classify cancellations and siren tests as informational

Validation: `go test ./...` and `go vet ./...`