### PR TITLE
fix(ui): set Leaflet maxZoom for OpenFreeMap globe

### DIFF
--- a/src/components/GlobeView.tsx
+++ b/src/components/GlobeView.tsx
@@ -14,7 +14,7 @@ import { isIncidentAnchor } from "@/lib/incident-links";
 import { countryCentroid } from "@/lib/country-centroids";
 import { alertMatchesRegionFilter } from "@/lib/regions";
 import { severityHex, textHex } from "@/lib/theme";
-import { addDarkBasemap, OPENFREEMAP_ATTRIBUTION } from "@/lib/basemap";
+import { addDarkBasemap, MAP_MAX_ZOOM, OPENFREEMAP_ATTRIBUTION } from "@/lib/basemap";
 import { loadOverlayDefs, loadOverlay, type OverlayDef, type OverlayId } from "@/lib/map-overlays";
 import { detectSpikes } from "@/lib/activity-spikes";
 import { getConflictLensById, type ConflictLens } from "@/lib/conflict-lenses";
@@ -622,6 +622,7 @@ export function GlobeView({
       center: vp.center,
       zoom: vp.zoom,
       minZoom: 3,
+      maxZoom: MAP_MAX_ZOOM,
       maxBounds: L.latLngBounds([-85, -180], [85, 180]),
       maxBoundsViscosity: 1.0,
       zoomControl: false,

--- a/src/lib/basemap.test.ts
+++ b/src/lib/basemap.test.ts
@@ -4,15 +4,26 @@
  * See NOTICE for provenance and LICENSE for repository-local terms.
  */
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import L from "leaflet";
 import caddyfile from "../../docker/Caddyfile?raw";
 import globeSource from "../components/GlobeView.tsx?raw";
 import mobileSource from "../mobile/MobileMapView.tsx?raw";
 import {
+  addDarkBasemap,
+  MAP_MAX_ZOOM,
   OPENFREEMAP_ATTRIBUTION,
   OPENFREEMAP_DARK_STYLE,
   OPENFREEMAP_TILE_ORIGIN,
 } from "./basemap";
+
+vi.mock("@maplibre/maplibre-gl-leaflet", () => ({
+  maplibreGL: () => ({
+    addTo(map: L.Map) {
+      return map;
+    },
+  }),
+}));
 
 describe("basemap", () => {
   it("uses OpenFreeMap dark vector style, not CARTO raster tiles", () => {
@@ -32,9 +43,21 @@ describe("basemap", () => {
     for (const src of [globeSource, mobileSource]) {
       expect(src).toContain("addDarkBasemap");
       expect(src).toContain("OPENFREEMAP_ATTRIBUTION");
+      expect(src).toContain("maxZoom: MAP_MAX_ZOOM");
       expect(src).not.toMatch(/cartocdn|carto\.com/i);
       expect(src).not.toContain("tile.openstreetmap.org");
     }
+  });
+
+  it("sets a finite maxZoom so markercluster can attach", () => {
+    const el = document.createElement("div");
+    document.body.appendChild(el);
+    const map = L.map(el, { center: [0, 0], zoom: 3 });
+    expect(Number.isFinite(map.getMaxZoom())).toBe(false);
+    addDarkBasemap(map);
+    expect(map.getMaxZoom()).toBe(MAP_MAX_ZOOM);
+    map.remove();
+    el.remove();
   });
 
   it("allows OpenFreeMap over CSP and drops CARTO tile hosts", () => {

--- a/src/lib/basemap.ts
+++ b/src/lib/basemap.ts
@@ -12,8 +12,12 @@ export const OPENFREEMAP_TILE_ORIGIN = "https://tiles.openfreemap.org";
 export const OPENFREEMAP_DARK_STYLE = `${OPENFREEMAP_TILE_ORIGIN}/styles/dark`;
 export const OPENFREEMAP_ATTRIBUTION =
   '<a href="https://openfreemap.org">OpenFreeMap</a> <a href="https://www.openmaptiles.org/">&copy; OpenMapTiles</a> Data from <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a>';
+export const MAP_MAX_ZOOM = 18;
 
 export function addDarkBasemap(map: L.Map): L.Layer {
+  if (!Number.isFinite(map.getMaxZoom())) {
+    map.setMaxZoom(MAP_MAX_ZOOM);
+  }
   return maplibreGL({
     style: OPENFREEMAP_DARK_STYLE,
     attributionControl: false,

--- a/src/mobile/MobileMapView.tsx
+++ b/src/mobile/MobileMapView.tsx
@@ -7,7 +7,7 @@ import { Layers, Check, ExternalLink } from "lucide-react";
 import type { Alert } from "@/types/alert";
 import { severityHex } from "@/lib/theme";
 import { categoryLabels, freshnessLabel } from "@/lib/severity";
-import { addDarkBasemap, OPENFREEMAP_ATTRIBUTION } from "@/lib/basemap";
+import { addDarkBasemap, MAP_MAX_ZOOM, OPENFREEMAP_ATTRIBUTION } from "@/lib/basemap";
 import {
   DEFAULT_OVERLAYS,
   loadOverlay,
@@ -65,6 +65,7 @@ export function MobileMapView({ alerts, regionFilter, onSelectAlert }: Props) {
     const map = L.map(containerRef.current, {
       center: vp.center,
       zoom: vp.zoom,
+      maxZoom: MAP_MAX_ZOOM,
       zoomControl: false,
       attributionControl: false,
     });


### PR DESCRIPTION
## Summary

Live globe on osint.scalytics.io crashes with \`Map has no maxZoom specified\`. Markercluster needs a finite Leaflet maxZoom. The old CARTO tile layer supplied 18; the MapLibre vector layer does not.

Sets \`maxZoom: 18\` on desktop and mobile maps, and \`addDarkBasemap\` fills it in if missing.

The Safari CSP message on line 40 is Cloudflare's injected challenge iframe, not the map. MapLibre is loading (sprite warning). That inline script is unrelated.

## Validation

- \`npx tsc -b\`
- \`npx vitest run\`
- \`src/lib/basemap.test.ts\` covers the markercluster maxZoom contract